### PR TITLE
chore: Update resource paths to use "/static" prefix to facilitate filtering

### DIFF
--- a/src/main/java/com/example/VieTicketSystem/config/MvcConfig.java
+++ b/src/main/java/com/example/VieTicketSystem/config/MvcConfig.java
@@ -1,0 +1,15 @@
+package com.example.VieTicketSystem.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/static/**")
+                .addResourceLocations("classpath:/static/");
+    }
+}

--- a/src/main/java/com/example/VieTicketSystem/fileSever/config/AuthFilter.java
+++ b/src/main/java/com/example/VieTicketSystem/fileSever/config/AuthFilter.java
@@ -35,13 +35,11 @@ public class AuthFilter implements Filter {
         String requestURI = httpRequest.getRequestURI();
 
         // Bỏ qua filter cho các yêu cầu đến các tệp tĩnh (ví dụ: CSS, JavaScript)
-        String[] staticResources = {".css", ".js", ".jpg", ".jpeg", ".png", ".gif"};
-        for (String resource : staticResources) {
-            if (requestURI.endsWith(resource)) {
-                chain.doFilter(request, response);
-                return;
-            }
+        if (requestURI.startsWith("/static/")) {
+            chain.doFilter(request, response);
+            return;
         }
+
         User user = (User) session.getAttribute("activeOrganizer");
         user = user == null ? (User) session.getAttribute("activeUser") : user;
 

--- a/src/main/resources/templates/change-password.html
+++ b/src/main/resources/templates/change-password.html
@@ -7,7 +7,7 @@
     <title>Change Password</title>
     <link rel="icon" type="image/png"
         href="https://res.cloudinary.com/djcowpoua/image/upload/v1716277138/5E9B944E-8D69-4D6B-AF10-93526CF88EAA_invhvi.png">
-    <link rel="stylesheet" href="bootstrap-5.3.3-dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3-dist/css/bootstrap.min.css">
     <style>
         body {
             background-color: #15132b;
@@ -86,7 +86,7 @@
             <button type="submit" class="btn btn-primary">Change Password</button>
         </form>
     </div>
-    <script src="bootstrap-5.3.3-dist/js/bootstrap.bundle.min.js"></script>
+    <script src="/static/bootstrap-5.3.3-dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>

--- a/src/main/resources/templates/createEvent.html
+++ b/src/main/resources/templates/createEvent.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Add Event</title>
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="bootstrap-5.3.3-dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3-dist/css/bootstrap.min.css">
     <link rel="icon" type="image/png" href="https://res.cloudinary.com/djcowpoua/image/upload/v1716277138/5E9B944E-8D69-4D6B-AF10-93526CF88EAA_invhvi.png">
 </head>
 

--- a/src/main/resources/templates/inactive-account.html
+++ b/src/main/resources/templates/inactive-account.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Inactive Account</title>
     <!-- Bootstrap CSS -->
-    <link rel="stylesheet" href="bootstrap-5.3.3-dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3-dist/css/bootstrap.min.css">
     <link rel="icon" type="image/png" href="https://res.cloudinary.com/djcowpoua/image/upload/v1716277138/5E9B944E-8D69-4D6B-AF10-93526CF88EAA_invhvi.png">
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-PsSC83n7NDzQz3Etc6tGL5givL/4WT/7GwzNaHn8I1W0ko8+IiKOMYgDqMpK/gwuc1aAnqYx61Jj+TmIv+JX3w==" crossorigin="anonymous" referrerpolicy="no-referrer" />

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,9 +5,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Home VieTicket</title>
-    <link th:href="@{/css/index.css}" rel="stylesheet">
+    <link th:href="@{/static/css/index.css}" rel="stylesheet">
 
-    <link rel="stylesheet" href="bootstrap-5.3.3-dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/static/bootstrap-5.3.3-dist/css/bootstrap.min.css">
 
 
     <link rel="icon" type="image/png"
@@ -97,8 +97,8 @@
     </div>
 
 
-    <script src="bootstrap-5.3.3-dist/js/bootstrap.bundle.min.js"></script>
-    <script type="text/javascript" th:src="@{/js/index.js}"></script>
+    <script src="/static/bootstrap-5.3.3-dist/js/bootstrap.bundle.min.js"></script>
+    <script type="text/javascript" th:src="@{/static/js/index.js}"></script>
 
 </body>
 

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -7,7 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="icon" type="image/png"
         href="https://res.cloudinary.com/djcowpoua/image/upload/v1716277138/5E9B944E-8D69-4D6B-AF10-93526CF88EAA_invhvi.png">
-    <link rel="stylesheet" href="/css/style.css">
+    <link rel="stylesheet" href="/static/css/style.css">
     <style>
         body {
             background-color: #15132b;


### PR DESCRIPTION
The code changes update the resource paths in the HTML templates to use the "/static" prefix. This ensures that the static resources such as CSS and JavaScript files are properly loaded.