### PR TITLE
feat: Add actual refund amount to RefundOrder entity and update database schema

### DIFF
--- a/src/main/java/com/example/VieTicketSystem/config/AuthFilter.java
+++ b/src/main/java/com/example/VieTicketSystem/config/AuthFilter.java
@@ -114,6 +114,7 @@ public class AuthFilter implements Filter {
                                 || requestURI.startsWith("/createEventSuccess"))
                         || requestURI.startsWith("/eventEditPage") || requestURI.startsWith("/eventEditSubmit")
                         || requestURI.startsWith("/viewStatistics") || requestURI.startsWith("/eventUsers")
+                        || requestURI.startsWith("/organizer")
                         || requestURI.startsWith("/sendMailToAllUser")) {
                     if (requestURI.startsWith("/createEvent")) {
                         session.setAttribute("eventCreated", true);

--- a/src/main/java/com/example/VieTicketSystem/model/entity/RefundOrder.java
+++ b/src/main/java/com/example/VieTicketSystem/model/entity/RefundOrder.java
@@ -16,6 +16,7 @@ public class RefundOrder {
     private RefundStatus status; // The current status of the refund order.
     private LocalDateTime approvedOn; // The date and time when the refund order was approved.
     private LocalDateTime refundedOn; // The date and time when the refund was processed.
+    private int actualRefund; // The actual amount refunded to the user (70% of the total).
 
     public int getActualRefundAmount() {
         return (int) (total * 0.7);

--- a/src/main/java/com/example/VieTicketSystem/repo/EventRepo.java
+++ b/src/main/java/com/example/VieTicketSystem/repo/EventRepo.java
@@ -13,14 +13,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.example.VieTicketSystem.model.entity.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
-import com.example.VieTicketSystem.model.entity.Area;
-import com.example.VieTicketSystem.model.entity.Event;
 import com.example.VieTicketSystem.model.dto.EventStatistics;
-import com.example.VieTicketSystem.model.entity.SeatMap;
-import com.example.VieTicketSystem.model.entity.User;
 
 @Repository
 public class EventRepo {
@@ -30,7 +27,7 @@ public class EventRepo {
 
     private static final String SELECT_BY_ID_SQL = "SELECT * FROM Event WHERE event_id = ?";
     // KEEP WHITESPACE AFTER EACH CHUNK
-    private static final String SELECT_EVENT_BY_ORDER_ID = "SELECT E.event_id, E.name, E.start_date " +
+    private static final String SELECT_EVENT_BY_ORDER_ID = "SELECT E.event_id, E.name, E.start_date, E.organizer_id " +
             "FROM Event E " +
             "JOIN Area A ON E.event_id = A.event_id " +
             "JOIN `Row` R ON A.area_id = R.area_id " +
@@ -52,6 +49,7 @@ public class EventRepo {
                 event = new Event();
                 event.setEventId(rs.getInt("event_id"));
                 event.setName(rs.getString("name"));
+                event.setOrganizer(new Organizer() {{setUserId(rs.getInt("organizer_id"));}});
 
                 Timestamp timestamp = rs.getTimestamp("start_date");
                 event.setStartDate(timestamp == null ? null : timestamp.toLocalDateTime());

--- a/src/main/java/com/example/VieTicketSystem/repo/TicketRepo.java
+++ b/src/main/java/com/example/VieTicketSystem/repo/TicketRepo.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.example.VieTicketSystem.model.entity.Order;
-import com.example.VieTicketSystem.model.entity.Seat;
 import org.springframework.stereotype.Repository;
 
 import com.example.VieTicketSystem.model.entity.Ticket;
@@ -97,6 +96,38 @@ public class TicketRepo {
             ps.executeBatch();
             ps.close();
         }
+    }
+
+    public void updateStatusByOrderIdAndStatus(int orderId, int status, int newStatus) throws Exception {
+        try (Connection con = ConnectionPoolManager.getConnection()) {
+            PreparedStatement ps = con.prepareStatement("UPDATE Ticket SET status = ? WHERE order_id = ? AND status = ?");
+            ps.setInt(1, newStatus);
+            ps.setInt(2, orderId);
+            ps.setInt(3, status);
+            ps.executeUpdate();
+            ps.close();
+        }
+    }
+
+    public List<Integer> findSeatIdsByOrderIdAndStatus(int orderid, int status) throws SQLException {
+        List<Integer> seatIds = new ArrayList<>();
+
+        try (Connection con = ConnectionPoolManager.getConnection()) {
+
+            PreparedStatement ps = con.prepareStatement("SELECT DISTINCT seat_id FROM Ticket WHERE order_id = ? AND status = ?");
+            ps.setInt(1, orderid);
+            ps.setInt(2, status);
+
+            ResultSet rs = ps.executeQuery();
+
+            while (rs.next()) {
+                seatIds.add(rs.getInt("seat_id"));
+            }
+            rs.close();
+            ps.close();
+        }
+
+        return seatIds;
     }
 
     public List<Ticket> findByOrderId(int orderId) throws Exception {

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -105,14 +105,15 @@ CREATE TABLE `Row`
 
 CREATE TABLE RefundOrder
 (
-    order_id    INT AUTO_INCREMENT
+    order_id      INT AUTO_INCREMENT
         PRIMARY KEY,
     FOREIGN KEY (order_id) REFERENCES `Order` (order_id),
-    total       INT,
-    created_on  TIMESTAMP,
-    status      TINYINT,
-    approved_on TIMESTAMP,
-    refunded_on TIMESTAMP
+    total         INT,
+    created_on    TIMESTAMP,
+    status        TINYINT,
+    approved_on   TIMESTAMP,
+    refunded_on   TIMESTAMP,
+    actual_refund INT
 );
 
 CREATE TABLE Seat

--- a/src/main/resources/templates/orders/view.html
+++ b/src/main/resources/templates/orders/view.html
@@ -19,6 +19,7 @@
     </h2>
 
     <h3>Order Information</h3>
+    <p>If there are any problems about your order, kindly contact support at <a href="mailto:support@vieticket.io.vn">support@vieticket.io.vn</a>.</p>
     <table class="table table-striped">
         <tr>
             <td>Total:</td>
@@ -41,7 +42,6 @@
 
     <div th:if="${refundOrder != null}">
         <h3>Refund Request Information</h3>
-
         <table class="table table-striped">
             <tr>
                 <td>Total:</td>
@@ -62,8 +62,8 @@
             </tr>
             <tr th:if="${refundOrder.status.toString() == 'APPROVED' || refundOrder.status.toString() == 'REJECTED'}">
                 <td>
-                    <span th:if="refundOrder.status.toString() == 'APPROVED'">Approved </span>
-                    <span th:if="refundOrder.status.toString() == 'REJECTED'">Rejected </span>
+                    <span th:if="${refundOrder.status.toString() == 'APPROVED'}">Approved </span>
+                    <span th:if="${refundOrder.status.toString() == 'REJECTED'}">Rejected </span>
                     on:
                 </td>
                 <td th:text="${refundOrder.approvedOn}"></td>
@@ -75,7 +75,8 @@
         </table>
     </div>
 
-    <p th:if="${!isReturnable}">Unfortunately, this order cannot be returned<span th:if="${refundOrder != null}"> more than one time</span>.
+    <p th:if="${!isReturnable}">
+        Unfortunately, this order cannot be returned.
     </p>
 
     <form action="/orders/request-refund" method="post">
@@ -167,10 +168,16 @@
                 .then(data => {
                     console.log(data);
                     // Handle success, e.g., show a success message
+                    alert('Refund request has been submitted');
                 })
                 .catch((error) => {
                     console.error('Error:', error);
-                    // Handle error, e.g., show an error message
+                    // Alert the error message from the response
+                    alert('Error: ' + error.message);
+                })
+                .finally(() => {
+                    // Reload the page after the request is completed
+                    location.reload();
                 });
         });
     });

--- a/src/main/resources/templates/organizer/refund.html
+++ b/src/main/resources/templates/organizer/refund.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" data-bs-theme="dark" lang="en">
 <head>
-    <title>Danh sách người dùng</title>
+    <title>List of Refund Requests</title>
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
@@ -29,75 +29,94 @@
         </div>
 
         <div class="btn-group text-end" role="group" aria-label="Basic example">
-            <a th:href="@{/organizer/refund-list(to-approve=true,eventId=${eventId})}" class="btn btn-outline-primary">To
+            <a th:href="@{/organizer/refund-list(eventId=${event.eventId})}" class="btn btn-outline-primary">To
                 approve</a>
-            <a th:href="@{/organizer/refund-list/approved(eventId=${eventId})}" class="btn btn-outline-primary">Approved</a>
-            <a th:href="@{/organizer/refund-list/rejected(eventId=${eventId})}" class="btn btn-outline-primary">Rejected</a>
+            <a th:href="@{/organizer/refund-list/approved(eventId=${event.eventId})}" class="btn btn-outline-primary">Approved</a>
+            <a th:href="@{/organizer/refund-list/rejected(eventId=${event.eventId})}" class="btn btn-outline-primary">Rejected</a>
         </div>
     </div>
 
-    <h2 class="text-center mt-4 mb-4" th:text="${title}"></h2>
+    <h2 class="text-center mt-4 mb-2" th:text="${title}"></h2>
+
+    <p class="text-center mb-4">For event: <span th:text="${event.name}"></span></p>
 
     <p class="text-center fw-bold" th:if="${refundOrders == null || refundOrders.isEmpty()}">There's nothing here.</p>
 
-    <table th:if="${refundOrders != null && !refundOrders.isEmpty()}" class="table table-striped table-bordered">
-        <thead>
-        <tr>
-            <th>
-                Order ID
-            </th>
-            <th>
-                User
-            </th>
-            <th>
-                Total
-            </th>
-            <th>
-                Timestamps
-            </th>
-            <th>
-                Status
-            </th>
-            <th>
-                Action
-            </th>
-        </tr>
-        </thead>
-        <tbody>
-        <tr th:each="refundOrder : ${refundOrders}">
-            <td th:text="${refundOrder.order.orderId}"></td>
-            <td>
-                <p><span class="fw-bold">Full Name:</span> <span th:text="${refundOrder.order.user.fullName}"></span>
-                </p>
-                <p><span class="fw-bold">Email:</span> <span th:text="${refundOrder.order.user.email}"></span></p>
-                <p><span class="fw-bold">Phone:</span> <span th:text="${refundOrder.order.user.phone}"></span></p>
-            </td>
-            <td>
-                <p><span class="fw-bold">Order:</span> <span class="price" th:attr="data-price=${refundOrder.order.total}"></span></p>
-                <p><span class="fw-bold">Refund:</span> <span class="price" th:attr="data-price=${refundOrder.total}"></span></p>
-            </td>
-            <td>
-                <p><span class="fw-bold">Purchased:</span> <span th:text="${refundOrder.order.date}"></span></p>
-                <p><span class="fw-bold">Requested:</span> <span th:text="${refundOrder.createdOn}"></span></p>
-                <p th:if="${refundOrder.approvedOn != null}">
-                    <span class="fw-bold" th:if="${refundOrder.status == 'APPROVED'}">Approved:</span>
-                    <span class="fw-bold" th:if="${refundOrder.status == 'REJECTED'}">Rejected:</span>
-                    <span th:text="${refundOrder.approvedOn}"></span>
-                </p>
-                <p th:if="${refundOrder.refundedOn != null}"><span class="fw-bold">Refunded:</span> <span th:text="${refundOrder.refundedOn}"></span></p>
-            </td>
-            <td th:text="${refundOrder.status}"></td>
-            <td>
-                <button title="Approve" aria-label="Approve" class="btn btn-outline-success"><i class="bi bi-check-lg"></i>
-                </button>
-                <button title="Reject" aria-label="Reject" class="btn btn-outline-danger"><i class="bi bi-x-lg"></i>
-                </button>
-                <button title="View Detail" aria-label="View Detail" class="btn btn-outline-primary"><i
-                        class="bi bi-eye-fill"></i></button>
-            </td>
-        </tr>
-        </tbody>
-    </table>
+    <div class="table-responsive">
+        <table th:if="${refundOrders != null && !refundOrders.isEmpty()}" class="table table-striped table-bordered">
+            <thead>
+            <tr>
+                <th>
+                    Order ID
+                </th>
+                <th>
+                    User
+                </th>
+                <th>
+                    Total
+                </th>
+                <th>
+                    Timestamps
+                </th>
+                <th>
+                    Status
+                </th>
+                <th>
+                    Action
+                </th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="refundOrder : ${refundOrders}">
+                <td th:text="${refundOrder.order.orderId}"></td>
+                <td>
+                    <p><span class="fw-bold">Full Name:</span> <span
+                            th:text="${refundOrder.order.user.fullName}"></span>
+                    </p>
+                    <p><span class="fw-bold">Email:</span> <span th:text="${refundOrder.order.user.email}"></span></p>
+                    <p><span class="fw-bold">Phone:</span> <span th:text="${refundOrder.order.user.phone}"></span></p>
+                </td>
+                <td>
+                    <p><span class="fw-bold">Order:</span> <span class="price"
+                                                                 th:attr="data-price=${refundOrder.order.total}"></span>
+                    </p>
+                    <p><span class="fw-bold">Refund:</span> <span class="price"
+                                                                  th:attr="data-price=${refundOrder.total}"></span></p>
+                </td>
+                <td>
+                    <p><span class="fw-bold">Purchased:</span> <span th:text="${refundOrder.order.date}"></span></p>
+                    <p><span class="fw-bold">Requested:</span> <span th:text="${refundOrder.createdOn}"></span></p>
+                    <p th:if="${refundOrder.approvedOn != null}">
+                        <span class="fw-bold" th:if="${refundOrder.status.toString() == 'APPROVED'}">Approved:</span>
+                        <span class="fw-bold" th:if="${refundOrder.status.toString() == 'REJECTED'}">Rejected:</span>
+                        <span th:text="${refundOrder.approvedOn}"></span>
+                    </p>
+                    <p th:if="${refundOrder.refundedOn != null}"><span class="fw-bold">Refunded:</span> <span
+                            th:text="${refundOrder.refundedOn}"></span></p>
+                </td>
+                <td>
+                    <p><span class="fw-bold">Refund:</span> <span th:text="${refundOrder.status}"></span></p>
+                    <p><span class="fw-bold">Order:</span> <span th:text="${refundOrder.order.status}"></span></p>
+                </td>
+                <td>
+                    <span th:if="${refundOrder.status.toString() == 'CREATED'}">
+                        <button title="Approve" aria-label="Approve" class="btn btn-outline-success approve-refund"
+                                th:data-order-id="${refundOrder.order.orderId}">
+                            <i class="bi bi-check-lg"></i>
+                        </button>
+                        <button title="Reject" aria-label="Reject" class="btn btn-outline-danger reject-refund"
+                                th:data-order-id="${refundOrder.order.orderId}">
+                            <i class="bi bi-x-lg"></i>
+                        </button>
+                    </span>
+                    <button title="View Detail" aria-label="View Detail" class="btn btn-outline-primary">
+                        <i class="bi bi-eye-fill"></i>
+                    </button>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
 </div>
 
 
@@ -111,6 +130,82 @@
     priceElements.forEach(priceElement => {
         let price = priceElement.dataset.price;
         priceElement.textContent = Number(price).toLocaleString('vi-VN', {style: 'currency', currency: 'VND'});
+    });
+
+    // Reject handler
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.reject-refund').forEach(button => {
+            button.addEventListener('click', function () {
+                const orderId = this.getAttribute('data-order-id');
+                fetch('/organizer/refund/reject?orderId=' + orderId, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        // Include other necessary headers like authorization if needed
+                    },
+                    // No need to send a body for this request as orderId is sent as a query parameter
+                })
+                    .then(response => {
+                        if (response.ok) {
+                            return response.text();
+                        } else {
+                            throw new Error('Something went wrong');
+                        }
+                    })
+                    .then(data => {
+                        console.log(data);
+                        // Handle success response, maybe refresh the page or show a success message
+                        alert('Refund request has been rejected');
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        // Handle error, maybe show an error message to the user
+                        alert('Error: ' + error.message);
+                    })
+                    .finally(() => {
+                        // Reload the page after the request is completed
+                        location.reload();
+                    });
+            });
+        });
+    });
+
+    // Approve handler
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.approve-refund').forEach(button => {
+            button.addEventListener('click', function () {
+                const orderId = this.getAttribute('data-order-id');
+                fetch('/organizer/refund/approve?orderId=' + orderId, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        // Include other necessary headers like authorization if needed
+                    },
+                    // No need to send a body for this request as orderId is sent as a query parameter
+                })
+                    .then(response => {
+                        if (response.ok) {
+                            return response.text();
+                        } else {
+                            throw new Error('Something went wrong');
+                        }
+                    })
+                    .then(data => {
+                        console.log(data);
+                        // Handle success response, maybe refresh the page or show a success message
+                        alert('Refund request has been approved');
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        // Handle error, maybe show an error message to the user
+                        alert('Error: ' + error.message);
+                    })
+                    .finally(() => {
+                        // Reload the page after the request is completed
+                        location.reload();
+                    });
+            });
+        });
     });
 </script>
 </body>


### PR DESCRIPTION
The code changes include adding a new field `actual_refund` to the `RefundOrder` entity class and modifying the corresponding database schema in the `schema.sql` file. This field represents the actual amount refunded to the user, which is calculated as 70% of the total refund amount.

Recent user commits and repository commits indicate the addition of refund functionality for users and the ability to view refund requests for organizers. There are also some unfinished tasks related to approving or rejecting refund requests.

Based on the code changes and recent commits, the suggested commit message is to add the actual refund amount to the `RefundOrder` entity and update the database schema.